### PR TITLE
small ca_cert fixup and gist read support (-r) added back to lib/gist.rb

### DIFF
--- a/gist
+++ b/gist
@@ -11,6 +11,9 @@
 #
 
 module Gist
+  VERSION = Version = '2.0.2'
+end
+module Gist
   module Manpage
     extend self
 
@@ -79,9 +82,6 @@ module Gist
     end
   end
 end
-module Gist
-  VERSION = Version = '2.0.2'
-end
 require 'open-uri'
 require 'net/https'
 require 'optparse'
@@ -90,6 +90,7 @@ require 'gist/manpage' unless defined?(Gist::Manpage)
 require 'gist/version' unless defined?(Gist::Version)
 
 module Gist
+  GIST_URL_REGEXP = /https?:\/\/gist.github.com\/\d+$/
   extend self
 
   GIST_URL   = 'https://gist.github.com/%s.txt'
@@ -104,6 +105,7 @@ module Gist
     gist_filename = nil
     gist_extension = defaults["extension"]
     browse_enabled = defaults["browse"]
+    read_mode=0
 
     opts = OptionParser.new do |opts|
       opts.banner = "Usage: gist [options] [filename or stdin] [filename] ...\n" +
@@ -126,6 +128,10 @@ module Gist
         Gist::Manpage.display("gist")
       end
 
+      opts.on('-r', '--read', 'Read Gist') do
+        read_mode = 1
+      end
+
       opts.on('-v', '--version', 'Print version') do
         puts Gist::Version
         exit
@@ -144,6 +150,14 @@ module Gist
 
         if args.empty?
           puts opts
+          exit
+        end
+
+        if read_mode == 1
+          ARGV.each do | gist_id_num |
+            next if gist_id_num =~ /^\-/
+            Gist.read( gist_id_num )
+          end
           exit
         end
 
@@ -184,6 +198,7 @@ module Gist
     http.use_ssl = true
     http.verify_mode = OpenSSL::SSL::VERIFY_PEER
     http.cert = OpenSSL::X509::Certificate.new(ca_cert)
+    http.ca_file = __FILE__
 
     req = Net::HTTP::Post.new(url.path)
     req.form_data = data(files, private_gist)
@@ -192,7 +207,8 @@ module Gist
   end
 
   def read(gist_id)
-    open(GIST_URL % gist_id).read
+    puts open(GIST_URL % gist_id).read unless gist_id.to_i.zero?
+    puts open(gist_id + '.txt').read if gist_id[GIST_URL_REGEXP]
   end
 
   def browse(url)
@@ -237,7 +253,11 @@ private
     user  = config("github.user")
     token = config("github.token")
 
-    user.to_s.empty? ? {} : { :login => user, :token => token }
+    if user.to_s.empty? || token.to_s.empty?
+      {}
+    else
+      { :login => user, :token => token }
+    end
   end
 
   def defaults


### PR DESCRIPTION
first issue:

when I clone gist it's non-functional out of the box

whitejs@eir:~/dev/git$ git clone https://github.com/defunkt/gist.git
Cloning into gist...
remote: Counting objects: 672, done.
remote: Compressing objects: 100% (323/323), done.
remote: Total 672 (delta 366), reused 586 (delta 318)
Receiving objects: 100% (672/672), 968.35 KiB | 779 KiB/s, done.
Resolving deltas: 100% (366/366), done.
whitejs@eir:~/dev/git$ cd gist
whitejs@eir:~/dev/git/gist$ ls | ./gist -
SSL_connect returned=1 errno=0 state=SSLv3 read server certificate B: certificate verify failed
Usage: gist [options] [filename or stdin] [filename] ...
Filename '-' forces gist to read from stdin.
-p, --[no-]private Make the gist private
-t, --type [EXTENSION] Set syntax highlighting of the Gist by file extension
-o, --[no-]open Open gist in browser
-m, --man Print manual
-v, --version Print version
-h, --help Display this screen

by inserting " http.ca_file = FILE" on line 187 of gist (corresponds to 124 of lib/gist.rb and running 'rake') I get:

whitejs@eir:~/dev/git/gist$ ls | ./gist -
https://gist.github.com/931390
second issue

adding -r back

~ line 17:
GIST_URL_REGEXP = /https?://gist.github.com/d+$/

added ~ line 107
read_mode = 0

gist
added ~ lines 130-132:
opts.on('-r', '--read', 'Read Gist') do
read_mode = 1
end

added lines ~155-161:
if read_mode == 1
ARGV.each do | gist_id_num |
next if gist_id_num =~ /^-/
Gist.read( gist_id_num )
end
exit
end

added lines ~ 212-215
def read(gist_id)
puts open(GIST_URL % gist_id).read unless gist_id.to_i.zero?
puts open(gist_id + '.txt').read if gist_id[GIST_URL_REGEXP]
end

so now:
whitejs@eir:~/dev/git/gist$ ls | gist -
https://gist.github.com/931507
whitejs@eir:~/dev/git/gist$ gist -r https://gist.github.com/931507
battle.png
bin
gist
gist.gemspec
lib
LICENSE
man
Rakefile
README.markdown
